### PR TITLE
add renderer to choice how link is generate

### DIFF
--- a/src/components/assets/Markdown.vue
+++ b/src/components/assets/Markdown.vue
@@ -127,10 +127,14 @@ onMounted(() => {
     }),
   )
 
+  const renderer = new marked.value.Renderer()
+  renderer.link = (href, title, text) => `<a target="_blank" href="${href}" title="${title}">${text}</a>`
+
   // Marked settings
   marked.value.setOptions({
     mangle: false,
     headerIds: false,
+    renderer,
   })
 
   generateMarkdown(props.markdown)


### PR DESCRIPTION
Add target="_blank" foreach link inside markdown.

Closes #3 